### PR TITLE
Replace `path` plugin config with simpler `package`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Now add this to protractor.conf.js ()
 
 ```js
 plugins: [{
-	path: 'node_modules/protractor-testability-plugin'
+	package: 'protractor-testability-plugin'
 }],
 ```
 ## Automatic waits


### PR DESCRIPTION
This is more universally applicable.
Tested with Protractor 2.2.0, 2.5.1, and 4.0.8.

Protractor since v1.5 (as far as I can tell) has supported a `package`
option for plugin configuration that is passed straight to node's
`require()`. This means it doesn't need a relative path to the module,
which can change depepnding on the location of the Protractor conf file.