### PR TITLE
Upgrade Protractor dependency to include v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-- '4.0'
+- 4
+- 5
+- 6
 before_install: npm install -g grunt-cli
-before_script:
-    - ./node_modules/.bin/webdriver-manager update
 env:
   SAUCE_ACCESS_KEY=af8788b9-bde3-4e85-8557-cacfbac98cdc
   SAUCE_USERNAME=alfonso-presa

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "node": ">= 4.0.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "protractor": "protractor test/protractor.conf.js",
+    "update-webdriver": "webdriver-manager update"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
@@ -29,16 +31,19 @@
     "grunt-conventional-changelog": "^1.1.0",
     "grunt-groc": "^0.4.5",
     "grunt-jscs": "^1.1.0",
-    "grunt-protractor-runner": "^2.0.0",
     "grunt-sauce-connect-launcher": "^0.3.1",
+    "grunt-shell": "^1.3.1",
     "grunt-umd": "^2.3.0",
     "jit-grunt": "^0.7.0",
     "jshint-stylish": "^0.2.0",
     "load-grunt-config": "^0.10.0",
+    "protractor": ">=2.2.0",
     "time-grunt": "^0.3.2"
   },
   "dependencies": {
-    "protractor": "^2.2.0",
     "testability.js": "0.x"
+  },
+  "peerDependencies": {
+    "protractor": ">=2.2.0"
   }
 }

--- a/tasks/aliases.yaml
+++ b/tasks/aliases.yaml
@@ -4,7 +4,7 @@ default:
 test:
   - connect:serve
   - sauce_connect
-  - protractor
+  - shell:protractor
   - sauce-connect-close
 
 build:

--- a/tasks/protractor.js
+++ b/tasks/protractor.js
@@ -1,7 +1,0 @@
-module.exports = {
-  options: {
-    configFile: 'test/protractor.conf.js',
-    keepAlive: false
-  },
-  test: {}
-};

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -1,0 +1,5 @@
+module.exports = {
+  protractor: {
+    command: 'npm run update-webdriver && npm run protractor'
+  }
+};


### PR DESCRIPTION
This replaces grunt-protractor-runner with a shell command so any
Protractor version later than the currently-supported v2.2.0 can be
used. (See also https://github.com/teerapap/grunt-protractor-runner/pull/164)

Also I don't think Protractor needs to be installed as
a dependency, so this moves it to a peer-dependency whilst also
including it as a dev-dependency so it can be run in the tests.