### PR TITLE
Use console.log instead of throw when testability is missing

### DIFF
--- a/dist/protractor-testability-plugin.js
+++ b/dist/protractor-testability-plugin.js
@@ -33,14 +33,15 @@ return (module.exports = {
         browser.executeScript('if(!window.testability) {(function(){' +
             testability +
         '}.bind(window))()}');
-        browser.executeScript(function (browserInstrumentation) {
-            var head = document.getElementsByTagName('head')[0];
-            var scriptText='(' + browserInstrumentation + ')();';
-            var scriptEl = document.createElement( 'script' );
-            scriptEl.type = 'text/javascript';
-            scriptEl.textContent = scriptText;
-            head.insertBefore( scriptEl, head.firstChild );
-        }, browserInstrumentation.toString());
+        //browser.executeScript(function (browserInstrumentation) {
+            //var head = document.getElementsByTagName('head')[0];
+            //var scriptText='(' + browserInstrumentation + ')();';
+            //var scriptEl = document.createElement( 'script' );
+            //scriptEl.type = 'text/javascript';
+            //scriptEl.textContent = scriptText;
+            //head.insertBefore( scriptEl, head.firstChild );
+        //}, browserInstrumentation.toString());
+        browser.executeScript(browserInstrumentation);
         browser.executeScript(
             protractorBindings,
             JSON.stringify(this.config.customFrameworkTestability, function replacer (key, item) {

--- a/dist/protractor-testability-plugin.js
+++ b/dist/protractor-testability-plugin.js
@@ -1,6 +1,6 @@
-/*! protractor-testability-plugin - v1.2.0
- *  Release on: 2019-08-06
- *  Copyright (c) 2019 Alfonso Presa
+/*! protractor-testability-plugin - v2.0.2
+ *  Release on: 2021-05-21
+ *  Copyright (c) 2021 Alfonso Presa
  *  Licensed MIT */
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
@@ -55,7 +55,7 @@ return (module.exports = {
                 cb('Error, testability is not loaded in the browser window :-(.');
         }).then(function (browserErr) {
             if (browserErr) {
-                throw 'Error while waiting to sync with the page: ' + JSON.stringify(browserErr);
+                console.log('Error while waiting to sync with the page: ' + JSON.stringify(browserErr));
             }
         });
     }

--- a/dist/protractor-testability-plugin.min.js
+++ b/dist/protractor-testability-plugin.min.js
@@ -1,6 +1,0 @@
-/*! protractor-testability-plugin - v1.2.0
- *  Release on: 2019-08-06
- *  Copyright (c) 2019 Alfonso Presa
- *  Licensed MIT */
-
-!function(t,e){"function"==typeof define&&define.amd?define([],function(){return e()}):"object"==typeof module&&module.exports?module.exports=e():e()}(0,function(){"use strict";var r=require("fs");return module.exports={name:"protractor-testability-plugin",onPageLoad:function(){var t=r.readFileSync(require.resolve("testability.js")).toString(),e=require("testability-browser-bindings"),i=require("./client/protractor-bindings");browser.executeScript("if(!window.testability) {(function(){"+t+"}.bind(window))()}"),browser.executeScript(function(t){var e=document.getElementsByTagName("head")[0],i="("+t+")();",r=document.createElement("script");r.type="text/javascript",r.textContent=i,e.insertBefore(r,e.firstChild)},e.toString()),browser.executeScript(i,JSON.stringify(this.config.customFrameworkTestability,function(t,e){return"function"==typeof e?"var temp="+e.toString()+";temp;":e}))},waitForPromise:function(){return browser.executeAsyncScript(function(t){return window.testability?window.testability.when.ready(t):t("Error, testability is not loaded in the browser window :-(.")}).then(function(t){if(t)throw"Error while waiting to sync with the page: "+JSON.stringify(t)})}}});

--- a/lib/protractor-testability-plugin.js
+++ b/lib/protractor-testability-plugin.js
@@ -13,14 +13,15 @@ return (module.exports = {
         browser.executeScript('if(!window.testability) {(function(){' +
             testability +
         '}.bind(window))()}');
-        browser.executeScript(function (browserInstrumentation) {
-            var head = document.getElementsByTagName('head')[0];
-            var scriptText='(' + browserInstrumentation + ')();';
-            var scriptEl = document.createElement( 'script' );
-            scriptEl.type = 'text/javascript';
-            scriptEl.textContent = scriptText;
-            head.insertBefore( scriptEl, head.firstChild );
-        }, browserInstrumentation.toString());
+        //browser.executeScript(function (browserInstrumentation) {
+            //var head = document.getElementsByTagName('head')[0];
+            //var scriptText='(' + browserInstrumentation + ')();';
+            //var scriptEl = document.createElement( 'script' );
+            //scriptEl.type = 'text/javascript';
+            //scriptEl.textContent = scriptText;
+            //head.insertBefore( scriptEl, head.firstChild );
+        //}, browserInstrumentation.toString());
+        browser.executeScript(browserInstrumentation);
         browser.executeScript(
             protractorBindings,
             JSON.stringify(this.config.customFrameworkTestability, function replacer (key, item) {

--- a/lib/protractor-testability-plugin.js
+++ b/lib/protractor-testability-plugin.js
@@ -35,7 +35,7 @@ return (module.exports = {
                 cb('Error, testability is not loaded in the browser window :-(.');
         }).then(function (browserErr) {
             if (browserErr) {
-                throw 'Error while waiting to sync with the page: ' + JSON.stringify(browserErr);
+                console.log('Error while waiting to sync with the page: ' + JSON.stringify(browserErr));
             }
         });
     }


### PR DESCRIPTION
Currently if window.testability is missing it shows this at the end of
the test: `Failure during waitForPromise: undefined`.  From what
I've read there's not a great way to return an error from
`browser.executeAsyncScript` and so I've changed it to just
`console.log` which shows up nicely in the protractor output.

I have also made a change to how the `browserInstrumentation` script is injected. It now runs directly using `executeScript` instead of via a head tag. It was being blocked as an inline-script by our Content Security Policy.